### PR TITLE
55 improve preserve

### DIFF
--- a/R/apps.R
+++ b/R/apps.R
@@ -35,6 +35,11 @@ new_dash_board <- function(...) {
     snapshot_location <- Sys.getenv("SNAPSHOT_LOCATION")
   }
 
+  auto_snapshot <- FALSE
+  if (nchar(Sys.getenv("AUTO_SNAPSHOT")) > 0) {
+    auto_snapshot <- as.logical(Sys.getenv("AUTO_SNAPSHOT"))
+  }
+
   new_board(
     ...,
     class = c(sprintf("%s_board", dashboard_type), "dash_board"),
@@ -42,7 +47,10 @@ new_dash_board <- function(...) {
       dark_mode = "light",
       stacks_colors = hcl.colors(n_stacks, palette = stacks_color_palette),
       dashboard_type = dashboard_type,
-      snapshot_location = snapshot_location
+      snapshot = list(
+        location = snapshot_location,
+        auto = auto_snapshot
+      )
     )
   )
 }

--- a/R/apps.R
+++ b/R/apps.R
@@ -30,13 +30,19 @@ new_dash_board <- function(...) {
     dashboard_type <- validate_dashboard_type(Sys.getenv("DASHBOARD_TYPE"))
   }
 
+  snapshot_location <- tempdir()
+  if (nchar(Sys.getenv("SNAPSHOT_LOCATION")) > 0) {
+    snapshot_location <- Sys.getenv("SNAPSHOT_LOCATION")
+  }
+
   new_board(
     ...,
     class = c(sprintf("%s_board", dashboard_type), "dash_board"),
     options = new_board_options(
       dark_mode = "light",
       stacks_colors = hcl.colors(n_stacks, palette = stacks_color_palette),
-      dashboard_type = dashboard_type
+      dashboard_type = dashboard_type,
+      snapshot_location = snapshot_location
     )
   )
 }

--- a/R/main.R
+++ b/R/main.R
@@ -47,18 +47,27 @@ create_app_state.dock_board <- function(board) {
     in_grid = list(),
     refreshed = NULL,
     network = structure(list(), class = "network"),
-    add_block = NULL,
+    # Blocks/nodes
     append_block = FALSE,
     added_block = NULL,
     removed_block = NULL,
     selected_block = NULL,
+    # Edges
     cancelled_edge = NULL,
     added_edge = NULL,
     removed_edge = NULL,
+    # Stacks
     added_stack = NULL,
     stack_added_block = NULL,
     stack_removed_block = NULL,
-    removed_stack = NULL
+    removed_stack = NULL,
+    # scoutbar
+    open_scoutbar = FALSE,
+    scoutbar_value = NULL,
+    scoutbar_blocks = list(),
+    scoutbar_snapshots = list(),
+    # For snapshots
+    backup_list = list()
   )
 }
 
@@ -110,7 +119,8 @@ main_server <- function(id, board) {
           block_visibility = manage_block_visibility,
           # Callback to signal other modules that the restore is done.
           # This allows to restore each part in the correct order.
-          on_board_restore = board_restore
+          on_board_restore = board_restore,
+          manage_scoutbar = manage_scoutbar
         ),
         parent = app_state
       )

--- a/R/plugin-add_rm_blocks.R
+++ b/R/plugin-add_rm_blocks.R
@@ -29,14 +29,20 @@ add_rm_block_server <- function(id, board, update, ...) {
 
       # Adding a block, we update the rv$added so the graph is updated
       # in the links plugin
-      observeEvent(dot_args$parent$scoutbar_value, {
-        new_blk <- as_blocks(create_block(dot_args$parent$scoutbar_value))
-        update(
-          list(blocks = list(add = new_blk))
-        )
-        dot_args$parent$added_block <- new_blk[[1]]
-        attr(dot_args$parent$added_block, "uid") <- names(new_blk)
-      })
+      observeEvent(
+        {
+          dot_args$parent$scoutbar
+          req(dot_args$parent$scoutbar$action == "add_block")
+        },
+        {
+          new_blk <- as_blocks(create_block(dot_args$parent$scoutbar$value))
+          update(
+            list(blocks = list(add = new_blk))
+          )
+          dot_args$parent$added_block <- new_blk[[1]]
+          attr(dot_args$parent$added_block, "uid") <- names(new_blk)
+        }
+      )
 
       # Remove block and node
       observeEvent(

--- a/R/plugin-add_rm_blocks.R
+++ b/R/plugin-add_rm_blocks.R
@@ -19,40 +19,6 @@ add_rm_block_server <- function(id, board, update, ...) {
       ns <- session$ns
       dot_args <- list(...)
 
-      # Hide add block in preview mode
-      observeEvent(dot_args$parent$preview, {
-        shinyjs::toggle(
-          "add_block",
-          condition = !dot_args$parent$preview
-        )
-      })
-
-      # Trigger add block
-      observeEvent(
-        req(dot_args$parent$add_block),
-        {
-          update_scoutbar(
-            session,
-            "scoutbar",
-            revealScoutbar = TRUE
-          )
-        }
-      )
-
-      # Reset dot_args$parent$append_block is user
-      # accidentally close the scoutbar without selecting
-      # a block, so that the scoutbar can open again on the
-      # next input$append_block or from the links plugin.
-      observeEvent(
-        input[["scoutbar-open"]],
-        {
-          if (!input[["scoutbar-open"]]) {
-            dot_args$parent$append_block <- FALSE
-            dot_args$parent$add_block <- FALSE
-          }
-        }
-      )
-
       # TBD: implement add_block_to -> add a block after the selected one
       # We need a contextual registry and update the scoutbar with relevant
       # choices. I think we can use the same scoutbar as for the classic
@@ -60,18 +26,11 @@ add_rm_block_server <- function(id, board, update, ...) {
       observeEvent(input$append_block, {
         dot_args$parent$append_block <- TRUE
       })
-      observeEvent(req(dot_args$parent$append_block), {
-        update_scoutbar(
-          session,
-          "scoutbar",
-          revealScoutbar = TRUE
-        )
-      })
 
       # Adding a block, we update the rv$added so the graph is updated
       # in the links plugin
-      observeEvent(input$scoutbar, {
-        new_blk <- as_blocks(create_block(input$scoutbar))
+      observeEvent(dot_args$parent$scoutbar_value, {
+        new_blk <- as_blocks(create_block(dot_args$parent$scoutbar_value))
         update(
           list(blocks = list(add = new_blk))
         )
@@ -116,14 +75,6 @@ add_rm_block_server <- function(id, board, update, ...) {
 #' @export
 add_rm_block_ui <- function(id, board) {
   list(
-    toolbar = tagList(
-      scoutbar(
-        NS(id, "scoutbar"),
-        placeholder = "Search for a block",
-        actions = blk_choices(),
-        showRecentSearch = TRUE
-      )
-    ),
     sidebar = div(
       class = "btn-group",
       role = "group",

--- a/R/plugin-links.R
+++ b/R/plugin-links.R
@@ -19,7 +19,7 @@ add_rm_link_server <- function(id, board, update, ...) {
       ns <- session$ns
       dot_args <- list(...)
 
-      # TBD When starting from non empty board (happens once)
+      # When starting from non empty board (happens once)
       observeEvent(
         req(
           isFALSE(dot_args$parent$cold_start),
@@ -31,7 +31,7 @@ add_rm_link_server <- function(id, board, update, ...) {
         once = TRUE
       )
 
-      # TBD Restore network from serialisation
+      # Restore network from serialisation
       observeEvent(req(dot_args$parent$refreshed == "board"), {
         restore_network(board, dot_args$parent, session)
       })

--- a/R/plugin-links.R
+++ b/R/plugin-links.R
@@ -55,7 +55,7 @@ add_rm_link_server <- function(id, board, update, ...) {
 
       # Trigger scoutbar from network menu
       observeEvent(input$add_block, {
-        dot_args$parent$add_block <- input$add_block
+        dot_args$parent$open_scoutbar <- input$add_block
       })
 
       # Add node to network board$nodes so the graph is updated

--- a/R/plugin-serialize.R
+++ b/R/plugin-serialize.R
@@ -104,26 +104,36 @@ ser_deser_server <- function(id, board, ...) {
       })
 
       # Restore from scoutbar choice
-      observeEvent(dot_args$parent$scoutbar_value, {
-        vals$auto_snapshot <- TRUE
-        tryCatch(
-          {
-            restore_board(dot_args$parent$scoutbar_value, res, dot_args$parent)
-          },
-          error = function(e) {
-            showNotification(
-              "Error restoring snapshot. It is possible that you try to restore an old state
+      observeEvent(
+        {
+          dot_args$parent$scoutbar
+          req(dot_args$parent$scoutbar$action == "restore_board")
+        },
+        {
+          vals$auto_snapshot <- TRUE
+          tryCatch(
+            {
+              restore_board(
+                dot_args$parent$scoutbar$value,
+                res,
+                dot_args$parent
+              )
+            },
+            error = function(e) {
+              showNotification(
+                "Error restoring snapshot. It is possible that you try to restore an old state
               that is not compatible with the current version",
-              tags$details(
-                tags$summary("Details"),
-                tags$small(e$message)
-              ),
-              duration = NA,
-              type = "error"
-            )
-          }
-        )
-      })
+                tags$details(
+                  tags$summary("Details"),
+                  tags$small(e$message)
+                ),
+                duration = NA,
+                type = "error"
+              )
+            }
+          )
+        }
+      )
 
       res
     }

--- a/R/plugin-serialize.R
+++ b/R/plugin-serialize.R
@@ -69,7 +69,7 @@ ser_deser_server <- function(id, board, ...) {
         observeEvent(
           c(vals$current_backup, dot_args$parent$backup_list),
           {
-            toggle_undo_redo(vals)
+            toggle_undo_redo(vals, parent)
           },
           ignoreNULL = TRUE
         )
@@ -114,26 +114,10 @@ ser_deser_server <- function(id, board, ...) {
           req(dot_args$parent$scoutbar$action == "restore_board")
         },
         {
-          tryCatch(
-            {
-              restore_board(
-                dot_args$parent$scoutbar$value,
-                res,
-                dot_args$parent
-              )
-            },
-            error = function(e) {
-              showNotification(
-                "Error restoring snapshot. It is possible that you try to restore an old state
-              that is not compatible with the current version",
-                tags$details(
-                  tags$summary("Details"),
-                  tags$small(e$message)
-                ),
-                duration = NA,
-                type = "error"
-              )
-            }
+          restore_board(
+            dot_args$parent$scoutbar$value,
+            res,
+            dot_args$parent
           )
         }
       )

--- a/R/utils-board.R
+++ b/R/utils-board.R
@@ -490,17 +490,14 @@ manage_scoutbar <- function(board, update, parent, ...) {
         scout_page(
           label = "Restore a snapshot",
           .list = lapply(
-            file.path(
-              get_board_option_value("snapshot_location"),
-              parent$backup_list
-            ),
-            \(file) {
-              infos <- file.info(file)
+            list_snapshot_files(board$board_id),
+            \(path) {
+              infos <- file.info(path)
               scout_action(
-                id = sprintf("%s@restore_board", file),
+                id = sprintf("%s@restore_board", path),
                 label = strsplit(
-                  file,
-                  get_board_option_value("snapshot_location"),
+                  path,
+                  path.expand(get_board_option_value("snapshot")$location),
                   ""
                 )[[1]][2],
                 description = sprintf(

--- a/R/utils-board.R
+++ b/R/utils-board.R
@@ -460,6 +460,7 @@ manage_scoutbar <- function(board, update, parent, ...) {
       if (!input[["scoutbar-open"]]) {
         parent$append_block <- FALSE
         parent$open_scoutbar <- FALSE
+        parent$scoutbar <- list()
       }
     }
   )

--- a/R/utils-serialize.R
+++ b/R/utils-serialize.R
@@ -112,11 +112,14 @@ blockr_deser.data.frame <- function(x, data, ...) {
 #' @rdname save-board
 board_filename <- function(rv) {
   function() {
-    paste0(
-      rv$board_id,
-      "_",
-      format(Sys.time(), "%Y-%m-%d_%H-%M-%S"),
-      ".json"
+    file.path(
+      get_board_option_value("snapshot_location"),
+      paste0(
+        rv$board_id,
+        "_",
+        format(Sys.time(), "%Y-%m-%d_%H-%M-%S"),
+        ".json"
+      )
     )
   }
 }
@@ -235,6 +238,7 @@ snapshot_board <- function(vals, rv, parent, session) {
   file_name <- board_filename(rv)()
   write_board_to_disk(rv, parent, session)(file_name)
   vals$backup_list <- list.files(
+    path = get_board_option_value("snapshot_location"),
     pattern = paste0("^", rv$board_id, ".*\\.json$")
   )
   vals$current_backup <- length(vals$backup_list)

--- a/R/utils-serialize.R
+++ b/R/utils-serialize.R
@@ -216,6 +216,15 @@ check_ser_deser_val <- function(val) {
   val
 }
 
+#' @keywords internal
+list_snapshot_files <- function(board_id) {
+  list.files(
+    path = get_board_option_value("snapshot")$location,
+    pattern = paste0("^", board_id, ".*\\.json$"),
+    full.names = TRUE
+  )
+}
+
 #' Capture board snapshot
 #'
 #' This is used to autosnapshot the board.
@@ -237,10 +246,7 @@ snapshot_board <- function(vals, rv, parent, session) {
 
   file_name <- board_filename(rv)()
   write_board_to_disk(rv, parent, session)(file_name)
-  vals$backup_list <- list.files(
-    path = get_board_option_value("snapshot_location"),
-    pattern = paste0("^", rv$board_id, ".*\\.json$")
-  )
+  vals$backup_list <- list_snapshot_files(rv$board_id)
   vals$current_backup <- length(vals$backup_list)
 }
 

--- a/inst/examples/dashboard/dock/app.R
+++ b/inst/examples/dashboard/dock/app.R
@@ -4,5 +4,9 @@ library(blockr.ai)
 library(blockr.io)
 library(blockr.ui)
 
-Sys.setenv("DASHBOARD_TYPE" = "dock", "SNAPSHOT_LOCATION" = "~/Downloads")
+Sys.setenv(
+  "DASHBOARD_TYPE" = "dock",
+  "SNAPSHOT_LOCATION" = "~/Downloads",
+  "AUTO_SNAPSHOT" = FALSE
+)
 run_demo_app()

--- a/inst/examples/dashboard/dock/app.R
+++ b/inst/examples/dashboard/dock/app.R
@@ -4,5 +4,5 @@ library(blockr.ai)
 library(blockr.io)
 library(blockr.ui)
 
-Sys.setenv("DASHBOARD_TYPE" = "dock")
+Sys.setenv("DASHBOARD_TYPE" = "dock", "SNAPSHOT_LOCATION" = "~/Downloads")
 run_demo_app()

--- a/man/handlers-utils.Rd
+++ b/man/handlers-utils.Rd
@@ -5,6 +5,7 @@
 \alias{manage_block_visibility}
 \alias{manage_app_mode}
 \alias{board_restore}
+\alias{manage_scoutbar}
 \title{Manage board sidebars}
 \usage{
 manage_sidebars(board, update, parent, ...)
@@ -14,6 +15,8 @@ manage_block_visibility(board, update, parent, ...)
 manage_app_mode(board, update, parent, ...)
 
 board_restore(board, update, parent, ...)
+
+manage_scoutbar(board, update, parent, ...)
 }
 \arguments{
 \item{board}{Board reactiveValues. Read-only.}
@@ -32,5 +35,7 @@ Manage blocks visibility
 Manage app mode
 
 Board restoration callback
+
+Scoutbar management callback
 }
 \keyword{internal}

--- a/man/toggle_undo_redo.Rd
+++ b/man/toggle_undo_redo.Rd
@@ -4,10 +4,12 @@
 \alias{toggle_undo_redo}
 \title{Toggle undo/redo}
 \usage{
-toggle_undo_redo(vals)
+toggle_undo_redo(vals, parent)
 }
 \arguments{
 \item{vals}{Local module reactive Values.}
+
+\item{parent}{Global reactive Values.}
 }
 \description{
 Toggle state of undo/redo buttons.


### PR DESCRIPTION
- Added manual save and restore button.
- Reworked scoutbaR that is now a board extension (callback). Reason is we can't have multiple scoutbaRs per page (as they are triggered by cmd + K). I added a section that corresponds to adding block and another page that is for snapshot restoration. Right now, there is no shortcut to open a specific page.
- Added 2 env vars `SNAPSHOT_LOCATION` and `AUTO_SNAPSHOT`:
```r
library(blockr.dplyr)
library(blockr.sdtm)
library(blockr.ai)
library(blockr.io)
library(blockr.ui)

Sys.setenv(
  "DASHBOARD_TYPE" = "dock",
  "SNAPSHOT_LOCATION" = "~/Downloads",
  "AUTO_SNAPSHOT" = FALSE
)
run_demo_app()
```
- Safely save and restore and return error messages in notifications.
- Disabled auto snapshot by default (as long as we can't find a reliable system to debounce the saving)...
- 