### PR TITLE
fix: get pkg in parent namespace

### DIFF
--- a/R/utils-module.R
+++ b/R/utils-module.R
@@ -52,7 +52,7 @@ new_board_module <- function(
     position = position,
     class = c(class, "board_module"),
     ctor = deparse(sys.call(sys.parent())[[1]]),
-    ctor_pkg = pkg_name()
+    ctor_pkg = pkg_name(parent.frame())
   )
 }
 

--- a/R/utils-serialize.R
+++ b/R/utils-serialize.R
@@ -90,11 +90,10 @@ restore_board.dag_board <- function(
     {
       tmp_res <- blockr_deser(new)
       tmp_res$board[["modules"]] <- lapply(tmp_res$modules, function(mod) {
-        fun <- get0(
+        fun <- get(
           mod$constructor,
           envir = asNamespace(mod$package),
-          mode = "function",
-          inherits = FALSE
+          mode = "function"
         )
         res <- fun()
         attr(res, "ctor") <- mod$constructor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects package context detection during module initialization to prevent misattribution and edge-case failures.
  * Improves function resolution to surface clear errors when required components are missing, avoiding silent fallbacks.
* **Reliability**
  * Enhances consistency across environments by tightening how dependencies are located and validated during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->