### PR TITLE
Replace numeric input with slider input

### DIFF
--- a/R/module-dashboard.R
+++ b/R/module-dashboard.R
@@ -150,12 +150,13 @@ new_dashboard_zoom_option <- function(
     id = "dashboard_zoom",
     default = value,
     ui = function(id) {
-      numericInput(
+      sliderInput(
         NS(id, "dashboard_zoom"),
         "Dashboard zoom factor",
-        value,
         min = 0.5,
         max = 2,
+        value = value,
+        ticks = FALSE,
         step = 0.1
       )
     },


### PR DESCRIPTION
The numeric input which controls the dashboard zoom level has two issues:

1. The user can easily override the intended min/max defaults of 0.5/2 by manually typing text into the box. this allows users to create unusable views, which we should prevent (here with a zoom of 10):

<img width="2240" height="906" alt="Screenshot 2025-10-06 at 10 50 17" src="https://github.com/user-attachments/assets/1a79c202-1b84-4c55-baab-b9816d81e9bb" />

2. The min/max defaults are not known without tapping the "up" and "down" arrows on the numeric input box until you find the boundaries.

Replacing the numeric input with a slider input fixes these issues:

1. Users can't override the min/max limits
2. Users can quickly visually see the min/max limits
3. Dragging a slider and seeing the dashboard grow/shrink feels more intuitive, and more like using a trackpad to zoom in/out with your fingers.

<img width="2238" height="988" alt="Screenshot 2025-10-06 at 11 46 08" src="https://github.com/user-attachments/assets/e20d8d32-e445-4930-a58b-43f46af68a29" />
